### PR TITLE
Updating the link to the latest docs

### DIFF
--- a/responses/00_explain-gh-script.md
+++ b/responses/00_explain-gh-script.md
@@ -1,6 +1,6 @@
 ## Create an issue comment
 
-If we take a look at the [Octokit documentation](https://octokit.github.io/rest.js/v17#issues-create-comment) on how to create issue comments we are greeted with the following method:
+If we take a look at the [Octokit documentation](https://octokit.github.io/rest.js/v18#issues-create-comment) on how to create issue comments we are greeted with the following method:
 
 **someFile.js**
 


### PR DESCRIPTION
The current link points to v17 docs which no longer exist. I changed it to point to v18 (current). Ideally, pointing to non-version specific page would be better, e.g. `https://octokit.github.io/rest.js/latest#issues-create-comment`, but I can't figure out how to do that.